### PR TITLE
fix: calendar UI/UX

### DIFF
--- a/lib/pearl/activities/activity_category.ex
+++ b/lib/pearl/activities/activity_category.ex
@@ -5,7 +5,6 @@ defmodule Pearl.Activities.ActivityCategory do
   use Pearl.Schema
 
   @required_fields ~w(name)a
-  @valid_names ~w(Talk Pitch Gameshow Workshop Break)
 
   schema "activity_categories" do
     field :name, :string
@@ -18,6 +17,5 @@ defmodule Pearl.Activities.ActivityCategory do
     activity_category
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
-    |> validate_inclusion(:name, @valid_names)
   end
 end

--- a/lib/pearl/activities/activity_category.ex
+++ b/lib/pearl/activities/activity_category.ex
@@ -5,6 +5,7 @@ defmodule Pearl.Activities.ActivityCategory do
   use Pearl.Schema
 
   @required_fields ~w(name)a
+  @valid_names ~w(Talk Pitch Gameshow Workshop Break)
 
   schema "activity_categories" do
     field :name, :string
@@ -17,5 +18,6 @@ defmodule Pearl.Activities.ActivityCategory do
     activity_category
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
+    |> validate_inclusion(:name, @valid_names)
   end
 end

--- a/lib/pearl_web/live/landing/components/schedule.ex
+++ b/lib/pearl_web/live/landing/components/schedule.ex
@@ -721,7 +721,7 @@ defmodule PearlWeb.Landing.Components.Schedule do
 
               <%= if @is_full and not @can_enrol and is_nil(@activity.link) do %>
                 <span class="px-5 py-2.5 bg-gray-100 text-gray-400 font-bold text-sm">
-                  {gettext("Esgotado")}
+                  {gettext("esgotado")}
                 </span>
               <% end %>
             <% end %>

--- a/lib/pearl_web/live/landing/components/schedule.ex
+++ b/lib/pearl_web/live/landing/components/schedule.ex
@@ -609,6 +609,7 @@ defmodule PearlWeb.Landing.Components.Schedule do
 
   defp render_activity_cell(assigns) do
     has_speakers = assigns.activity.speakers != []
+
     show_actions = assigns.variant in [:day, :calendar]
 
     activity_ticket_types = TicketTypes.list_active_activity_ticket_types()
@@ -684,7 +685,7 @@ defmodule PearlWeb.Landing.Components.Schedule do
               <%= cond do %>
                 <% @is_paid_activity && @activity_ticket_type && @can_enrol && not @is_full -> %>
                   <.primary_button
-                    title={gettext("Comprar")}
+                    title={gettext("comprar")}
                     icon="hero-arrow-right"
                     type="button"
                     phx-click="select_ticket"
@@ -701,11 +702,11 @@ defmodule PearlWeb.Landing.Components.Schedule do
                     class="flex items-center gap-2 px-4 py-2.5 bg-background-muted text-primary hover:bg-background-muted/80 text-sm font-bold"
                   >
                     <.icon name="hero-arrow-up-right" class="w-4 h-4 shrink-0" />
-                    <span>{gettext("Inscrever")}</span>
+                    <span>{gettext("inscrever")}</span>
                   </a>
                 <% @can_enrol -> %>
                   <.primary_button
-                    title={gettext("Inscrever")}
+                    title={gettext("inscrever")}
                     icon="hero-plus"
                     phx-click="enrol"
                     phx-value-activity_id={@activity.id}
@@ -776,27 +777,35 @@ defmodule PearlWeb.Landing.Components.Schedule do
   defp fetch_and_group_activities(day, filters) do
     Activities.list_daily_activities(day)
     |> Enum.filter(fn at -> filters == [] or at.category_id in filters end)
-    |> group_activities_by_start_time()
+    |> group_activities_in_blocks()
   end
 
-  defp group_activities_by_start_time(activities) do
-    Enum.reduce(activities, [], fn activity, acc ->
-      case acc do
-        [] ->
-          [[activity]]
+  def group_activities_in_blocks(activities) do
+    {standalone, regular} =
+      Enum.split_with(activities, fn a -> get_category_name(a) == "Break" end)
 
-        [[head | _tail] | _rest] = groups ->
-          case activity.time_start == head.time_start do
-            true -> prepend_to_first_group(activity, groups)
-            false -> [[activity] | groups]
+    standalone_blocks = Enum.map(standalone, fn a -> [a] end)
+
+    grouped =
+      regular
+      |> Enum.group_by(fn a -> {a.time_start, a.time_end} end)
+      |> Enum.sort_by(fn {{start, end_}, _} -> {start, end_} end)
+      |> Enum.map(fn {_key, group_acts} ->
+        Enum.sort_by(group_acts, fn act ->
+          case get_category_name(act) do
+            "Talk" -> 0
+            "Workshop" -> 1
+            _ -> 2
           end
-      end
-    end)
-    |> Enum.reverse()
-  end
+        end)
+      end)
 
-  defp prepend_to_first_group(activity, [[head | tail] | rest]) do
-    [[activity, head | tail] | rest]
+    (standalone_blocks ++ grouped)
+    |> Enum.sort_by(fn block ->
+      first = List.first(block)
+      is_break = get_category_name(first) == "Break"
+      {first.time_start, first.time_end, if(is_break, do: 0, else: 1)}
+    end)
   end
 
   defp can_enrol?(activity, user_role, enrolments) do

--- a/lib/pearl_web/live/landing/components/schedule.ex
+++ b/lib/pearl_web/live/landing/components/schedule.ex
@@ -693,6 +693,8 @@ defmodule PearlWeb.Landing.Components.Schedule do
                     phx-value-ticket_type_id={@activity_ticket_type.id}
                     phx-value-type="activity"
                     class="text-sm font-bold"
+                    disabled={is_nil(@current_user)}
+
                   />
                 <% @activity.link -> %>
                   <a

--- a/lib/pearl_web/live/landing/components/schedule.ex
+++ b/lib/pearl_web/live/landing/components/schedule.ex
@@ -737,7 +737,7 @@ defmodule PearlWeb.Landing.Components.Schedule do
             <%= if @is_enrolled do %>
               <div class="flex items-center gap-2 px-5 py-2.5 bg-green-100 text-green-700 font-bold text-sm">
                 <.icon name="hero-check-circle" class="size-5" />
-                {gettext("Inscrito")}
+                {gettext("inscrito")}
               </div>
             <% else %>
               <%= cond do %>

--- a/lib/pearl_web/live/landing/components/schedule.ex
+++ b/lib/pearl_web/live/landing/components/schedule.ex
@@ -694,7 +694,6 @@ defmodule PearlWeb.Landing.Components.Schedule do
                     phx-value-type="activity"
                     class="text-sm font-bold"
                     disabled={is_nil(@current_user)}
-
                   />
                 <% @activity.link -> %>
                   <a

--- a/lib/pearl_web/live/landing/components/schedule.ex
+++ b/lib/pearl_web/live/landing/components/schedule.ex
@@ -158,6 +158,17 @@ defmodule PearlWeb.Landing.Components.Schedule do
         close_button_button_class="-m-3 flex-none p-3 text-dark/85 hover:opacity-70"
         close_button_icon_class="size-8"
       >
+        <%
+          activity_ticket_type = activity_ticket_type(@selected_activity)
+          is_paid_activity = not is_nil(activity_ticket_type)
+          can_enrol = can_enrol?(@selected_activity, @user_role, @enrolments)
+          is_enrolled = already_enrolled?(@selected_activity, @enrolments)
+
+          is_full =
+            @selected_activity.has_enrolments and
+              @selected_activity.enrolment_count >= @selected_activity.max_enrolments
+        %>
+
         <div class="flex flex-col gap-2 pt-8 w-full">
           <span class="text-2xl md:text-4xl font-bold text-dark pr-10">
             Informações
@@ -239,6 +250,58 @@ defmodule PearlWeb.Landing.Components.Schedule do
             <div class="text-dark/75 w-full leading-relaxed">
               {@selected_activity.description || gettext("Sem descrição disponível.")}
             </div>
+          </div>
+
+          <div class="mt-6 pt-4 border-t border-light-muted/60">
+            <%= if is_enrolled do %>
+              <div class="inline-flex items-center gap-2 px-5 py-2.5 bg-green-100 text-green-700 font-bold text-sm">
+                <.icon name="hero-check-circle" class="size-5" />
+                {gettext("Inscrito")}
+              </div>
+            <% else %>
+              <%= cond do %>
+                <% is_paid_activity && activity_ticket_type && can_enrol && not is_full -> %>
+                  <.primary_button
+                    title={gettext("comprar")}
+                    icon="hero-arrow-right"
+                    type="button"
+                    phx-click="select_ticket"
+                    phx-target={@myself}
+                    phx-value-ticket_type_id={activity_ticket_type.id}
+                    phx-value-type="activity"
+                    class="text-sm font-bold"
+                    disabled={is_nil(@current_user)}
+                  />
+                <% @selected_activity.link -> %>
+                  <a
+                    href={@selected_activity.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-2 px-4 py-2.5 bg-background-muted text-primary hover:bg-background-muted/80 text-sm font-bold"
+                  >
+                    <.icon name="hero-arrow-up-right" class="w-4 h-4 shrink-0" />
+                    <span>{gettext("inscrever")}</span>
+                  </a>
+                <% can_enrol -> %>
+                  <.primary_button
+                    title={gettext("inscrever")}
+                    icon="hero-plus"
+                    phx-click="enrol"
+                    phx-value-activity_id={@selected_activity.id}
+                    phx-target={@myself}
+                    data-confirm={gettext("Tem certeza de que te queres inscrever?")}
+                    class="text-sm font-bold"
+                    disabled={is_nil(@current_user)}
+                  />
+                <% true -> %>
+              <% end %>
+
+              <%= if is_full and not can_enrol and is_nil(@selected_activity.link) do %>
+                <span class="inline-flex px-5 py-2.5 bg-gray-100 text-gray-400 font-bold text-sm">
+                  {gettext("esgotado")}
+                </span>
+              <% end %>
+            <% end %>
           </div>
         </div>
       </.modal>
@@ -612,10 +675,7 @@ defmodule PearlWeb.Landing.Components.Schedule do
 
     show_actions = assigns.variant in [:day, :calendar]
 
-    activity_ticket_types = TicketTypes.list_active_activity_ticket_types()
-
-    activity_ticket_type =
-      Enum.find(activity_ticket_types, fn tt -> tt.activity_id == assigns.activity.id end)
+    activity_ticket_type = activity_ticket_type(assigns.activity)
 
     is_paid_activity = not is_nil(activity_ticket_type)
 
@@ -730,6 +790,11 @@ defmodule PearlWeb.Landing.Components.Schedule do
       </div>
     </div>
     """
+  end
+
+  defp activity_ticket_type(activity) do
+    TicketTypes.list_active_activity_ticket_types()
+    |> Enum.find(fn tt -> tt.activity_id == activity.id end)
   end
 
   attr :activity, :map, required: true

--- a/lib/pearl_web/live/landing/components/schedule.ex
+++ b/lib/pearl_web/live/landing/components/schedule.ex
@@ -158,16 +158,14 @@ defmodule PearlWeb.Landing.Components.Schedule do
         close_button_button_class="-m-3 flex-none p-3 text-dark/85 hover:opacity-70"
         close_button_icon_class="size-8"
       >
-        <%
-          activity_ticket_type = activity_ticket_type(@selected_activity)
-          is_paid_activity = not is_nil(activity_ticket_type)
-          can_enrol = can_enrol?(@selected_activity, @user_role, @enrolments)
-          is_enrolled = already_enrolled?(@selected_activity, @enrolments)
+        <% activity_ticket_type = activity_ticket_type(@selected_activity)
+        is_paid_activity = not is_nil(activity_ticket_type)
+        can_enrol = can_enrol?(@selected_activity, @user_role, @enrolments)
+        is_enrolled = already_enrolled?(@selected_activity, @enrolments)
 
-          is_full =
-            @selected_activity.has_enrolments and
-              @selected_activity.enrolment_count >= @selected_activity.max_enrolments
-        %>
+        is_full =
+          @selected_activity.has_enrolments and
+            @selected_activity.enrolment_count >= @selected_activity.max_enrolments %>
 
         <div class="flex flex-col gap-2 pt-8 w-full">
           <span class="text-2xl md:text-4xl font-bold text-dark pr-10">

--- a/priv/repo/seeds/activities.exs
+++ b/priv/repo/seeds/activities.exs
@@ -63,11 +63,28 @@ defmodule Pearl.Repo.Seeds.Activities do
         name: "Workshop"
       },
       %{
+        name: "Activity"
+      },
+      %{
         name: "Break"
       }
     ]
 
-    for category <- categories do
+    existing_names =
+      Activities.list_activity_categories()
+      |> Enum.map(& &1.name)
+      |> MapSet.new()
+
+    categories_to_seed =
+      Enum.reject(categories, fn category ->
+        MapSet.member?(existing_names, category.name)
+      end)
+
+    if categories_to_seed == [] do
+      Mix.shell().info("Activity categories already seeded.")
+    end
+
+    for category <- categories_to_seed do
       changeset = ActivityCategory.changeset(%ActivityCategory{}, category)
 
       case Repo.insert(changeset) do
@@ -124,6 +141,8 @@ defmodule Pearl.Repo.Seeds.Activities do
       break: Enum.find(category_list, fn category -> category.name == "Break" end)
     }
 
+    validate_required_categories!(categories, category_list)
+
     seed_first_day_activities(categories, speakers)
     seed_last_days_activities(categories, speakers)
     seed_rally_de_tascas_activity()
@@ -131,7 +150,7 @@ defmodule Pearl.Repo.Seeds.Activities do
 
 defp seed_rally_de_tascas_activity do
   category_list = Activities.list_activity_categories()
-  gameshow_category = Enum.find(category_list, fn category -> category.name == "Gameshow" end)
+  gameshow_category = Enum.find(category_list, fn category -> category.name == "Activity" end)
 
   if is_nil(gameshow_category) do
     Mix.shell().error("Skipping Rally de Tascas: missing Gameshow category.")
@@ -144,7 +163,7 @@ defp seed_rally_de_tascas_activity do
       time_start: ~T[20:00:00],
       time_end: ~T[23:59:59],
       location: "Se' de Braga",
-      type: :gameshow,
+      type: :activity,
       date: friday,
       category_id: gameshow_category.id,
       has_enrolments: true,
@@ -178,10 +197,12 @@ end
   defp seed_first_day_activities(categories, speakers) do
     for activity <- first_day_seed_data() do
       type = activity.type
+      is_workshop = type == :workshop
+
       changeset = Activities.change_activity(%Activity{},
         activity
         |> Map.put(:date, next_first_tuesday_of_february())
-        |> Map.put(:category_id, Map.get(categories, type).id)
+        |> Map.put(:category_id, category_id_for_type!(categories, type))
         |> Map.put(:has_enrolments, is_workshop)
         |> Map.put(:max_enrolments,  if(is_workshop, do: 30, else: 0))
         |> Map.put(:title, Map.get(activity, :title) || Faker.Company.bs() |> String.capitalize())
@@ -202,7 +223,7 @@ end
         changeset = Activities.change_activity(%Activity{},
           activity
           |> Map.put(:date, Date.shift(next_first_tuesday_of_february(), day: i))
-          |> Map.put(:category_id, Map.get(categories, type).id)
+          |> Map.put(:category_id, category_id_for_type!(categories, type))
           |> Map.put(:has_enrolments, is_workshop)
           |> Map.put(:max_enrolments, if(is_workshop, do: 30, else: 0))
           |> Map.put(:title, Map.get(activity, :title) || Faker.Company.bs() |> String.capitalize())
@@ -224,6 +245,36 @@ end
       {:error, changeset} ->
         Mix.shell().error("Failed to insert activity: #{changeset.title}")
         Mix.shell().error(Kernel.inspect(changeset.errors))
+    end
+  end
+
+  defp category_id_for_type!(_categories, :none), do: nil
+
+  defp category_id_for_type!(categories, type) do
+    case Map.get(categories, type) do
+      %{id: category_id} ->
+        category_id
+
+      nil ->
+        Mix.raise("Missing category for activity type #{inspect(type)}.")
+    end
+  end
+
+  defp validate_required_categories!(categories, category_list) do
+    required_types = [:talk, :pitch, :gameshow, :workshop, :break]
+
+    missing_types =
+      Enum.filter(required_types, fn type ->
+        is_nil(Map.get(categories, type))
+      end)
+
+    if missing_types != [] do
+      existing_names = Enum.map_join(category_list, ", ", & &1.name)
+
+      Mix.raise(
+        "Missing required activity categories: #{Enum.map_join(missing_types, ", ", &inspect/1)}. " <>
+          "Existing categories: [#{existing_names}]."
+      )
     end
   end
 

--- a/priv/repo/seeds/activities.exs
+++ b/priv/repo/seeds/activities.exs
@@ -147,7 +147,7 @@ defp seed_rally_de_tascas_activity do
       type: :gameshow,
       date: friday,
       category_id: gameshow_category.id,
-      has_enrolments: false,
+      has_enrolments: true,
       max_enrolments: 30,
       description: "O mítico Rally de Tascas!"
     }
@@ -182,8 +182,8 @@ end
         activity
         |> Map.put(:date, next_first_tuesday_of_february())
         |> Map.put(:category_id, Map.get(categories, type).id)
-        |> Map.put(:has_enrolments, true)
-        |> Map.put(:max_enrolments, 30)
+        |> Map.put(:has_enrolments, is_workshop)
+        |> Map.put(:max_enrolments,  if(is_workshop, do: 30, else: 0))
         |> Map.put(:title, Map.get(activity, :title) || Faker.Company.bs() |> String.capitalize())
         |> Map.put(:description, Faker.Lorem.paragraph())
         |> Map.put(:location, Map.get(activity, :location) || "CP2 - B1"))

--- a/priv/repo/seeds/activities.exs
+++ b/priv/repo/seeds/activities.exs
@@ -37,9 +37,9 @@ defmodule Pearl.Repo.Seeds.Activities do
     case Activities.list_activities() do
       [] ->
         seed_activities()
-      _  ->
-        Mix.shell().error("Found activities, aborting seeding activities.")
-    end
+        _  ->
+          Mix.shell().error("Found activities, aborting seeding activities.")
+        end
   end
 
   def seed_event_schedule_config do
@@ -126,7 +126,54 @@ defmodule Pearl.Repo.Seeds.Activities do
 
     seed_first_day_activities(categories, speakers)
     seed_last_days_activities(categories, speakers)
+    seed_rally_de_tascas_activity()
   end
+
+defp seed_rally_de_tascas_activity do
+  category_list = Activities.list_activity_categories()
+  gameshow_category = Enum.find(category_list, fn category -> category.name == "Gameshow" end)
+
+  if is_nil(gameshow_category) do
+    Mix.shell().error("Skipping Rally de Tascas: missing Gameshow category.")
+  else
+    event_start_date = next_first_tuesday_of_february()
+    friday = Date.add(event_start_date, 2)
+
+    activity = %{
+      title: "Rally de Tascas",
+      time_start: ~T[20:00:00],
+      time_end: ~T[23:59:59],
+      location: "Se' de Braga",
+      type: :gameshow,
+      date: friday,
+      category_id: gameshow_category.id,
+      has_enrolments: false,
+      max_enrolments: 30,
+      description: "O mítico Rally de Tascas!"
+    }
+
+    existing_activity =
+      Repo.get_by(Activity,
+        title: activity.title,
+        date: activity.date,
+        time_start: activity.time_start,
+        time_end: activity.time_end
+      )
+
+    if is_nil(existing_activity) do
+      changeset = Activity.changeset(%Activity{}, activity)
+
+      case Repo.insert(changeset) do
+        {:ok, _act} -> :ok
+        {:error, changeset} ->
+          Mix.shell().error("Failed to insert Rally de Tascas activity")
+          Mix.shell().error(Kernel.inspect(changeset.errors))
+      end
+    else
+      Mix.shell().error("Rally de Tascas already seeded, skipping duplicate.")
+    end
+  end
+end
 
   defp seed_first_day_activities(categories, speakers) do
     for activity <- first_day_seed_data() do
@@ -135,8 +182,8 @@ defmodule Pearl.Repo.Seeds.Activities do
         activity
         |> Map.put(:date, next_first_tuesday_of_february())
         |> Map.put(:category_id, Map.get(categories, type).id)
-        |> Map.put(:has_enrolments, false)
-        |> Map.put(:max_enrolments, 0)
+        |> Map.put(:has_enrolments, true)
+        |> Map.put(:max_enrolments, 30)
         |> Map.put(:title, Map.get(activity, :title) || Faker.Company.bs() |> String.capitalize())
         |> Map.put(:description, Faker.Lorem.paragraph())
         |> Map.put(:location, Map.get(activity, :location) || "CP2 - B1"))
@@ -209,14 +256,23 @@ defmodule Pearl.Repo.Seeds.Activities do
       %{title: "Coffee Break", time_start: ~T[11:30:00], time_end: ~T[12:00:00], type: :break},
       %{time_start: ~T[12:00:00], time_end: ~T[13:00:00], type: :talk},
       %{title: "Lunch Break", time_start: ~T[13:00:00], time_end: ~T[14:00:00], type: :break},
-      %{time_start: ~T[14:00:00], time_end: ~T[15:00:00], type: :talk},
-      %{time_start: ~T[15:00:00], time_end: ~T[16:00:00], type: :talk},
+      %{title: "Talk 14-15", time_start: ~T[14:00:00], time_end: ~T[15:00:00], type: :talk, location: "CP2 - Test"},
+      %{title: "Workshop 15-16", time_start: ~T[15:00:00], time_end: ~T[16:00:00], type: :workshop, location: "CP2 - Test"},
+      %{title: "Gameshow 14-16", time_start: ~T[14:00:00], time_end: ~T[16:00:00], type: :gameshow, location: "CP2 - Test"},
       %{title: "Coffee Break", time_start: ~T[16:00:00], time_end: ~T[16:30:00], type: :break},
       %{time_start: ~T[16:30:00], time_end: ~T[16:45:00], type: :pitch},
       %{time_start: ~T[16:45:00], time_end: ~T[17:00:00], type: :pitch},
-      %{time_start: ~T[17:00:00], time_end: ~T[18:00:00], type: :gameshow}
+      %{time_start: ~T[17:00:00], time_end: ~T[18:00:00], type: :gameshow},
+      %{title: "Break Edge Same Slot", time_start: ~T[18:00:00], time_end: ~T[18:15:00], type: :break},
+      %{title: "Talk Edge Same Slot", time_start: ~T[18:00:00], time_end: ~T[18:15:00], type: :talk, location: "CP2 - B1"},
+      %{title: "Talk Edge Group A", time_start: ~T[18:15:00], time_end: ~T[19:00:00], type: :talk, location: "CP2 - B1"},
+      %{title: "Workshop Edge Group A", time_start: ~T[18:15:00], time_end: ~T[19:00:00], type: :workshop, location: "CP2 - 0.14"},
+      %{title: "Gameshow Edge Group A", time_start: ~T[18:15:00], time_end: ~T[19:00:00], type: :gameshow, location: "CP2 - 0.15"},
+      %{title: "Break Edge A", time_start: ~T[19:00:00], time_end: ~T[19:15:00], type: :break},
+      %{title: "Break Edge B", time_start: ~T[19:00:00], time_end: ~T[19:15:00], type: :break},
+      %{title: "Pitch Edge Different End", time_start: ~T[19:00:00], time_end: ~T[19:20:00], type: :pitch, location: "CP2 - B1"}
     ]
-  end
+   end
 
   defp last_days_seed_data do
     rooms = ["CP2 - 0.14", "CP2 - 0.15", "CP2 - 0.17"]

--- a/priv/repo/seeds/activities.exs
+++ b/priv/repo/seeds/activities.exs
@@ -141,8 +141,6 @@ defmodule Pearl.Repo.Seeds.Activities do
       break: Enum.find(category_list, fn category -> category.name == "Break" end)
     }
 
-    validate_required_categories!(categories, category_list)
-
     seed_first_day_activities(categories, speakers)
     seed_last_days_activities(categories, speakers)
     seed_rally_de_tascas_activity()
@@ -153,7 +151,7 @@ defp seed_rally_de_tascas_activity do
   gameshow_category = Enum.find(category_list, fn category -> category.name == "Activity" end)
 
   if is_nil(gameshow_category) do
-    Mix.shell().error("Skipping Rally de Tascas: missing Gameshow category.")
+    Mix.shell().error("Skipping Rally de Tascas: missing Activity category.")
   else
     event_start_date = next_first_tuesday_of_february()
     friday = Date.add(event_start_date, 2)
@@ -257,24 +255,6 @@ end
 
       nil ->
         Mix.raise("Missing category for activity type #{inspect(type)}.")
-    end
-  end
-
-  defp validate_required_categories!(categories, category_list) do
-    required_types = [:talk, :pitch, :gameshow, :workshop, :break]
-
-    missing_types =
-      Enum.filter(required_types, fn type ->
-        is_nil(Map.get(categories, type))
-      end)
-
-    if missing_types != [] do
-      existing_names = Enum.map_join(category_list, ", ", & &1.name)
-
-      Mix.raise(
-        "Missing required activity categories: #{Enum.map_join(missing_types, ", ", &inspect/1)}. " <>
-          "Existing categories: [#{existing_names}]."
-      )
     end
   end
 

--- a/priv/repo/seeds/tickets.exs
+++ b/priv/repo/seeds/tickets.exs
@@ -11,19 +11,51 @@ defmodule Pearl.Repo.Seeds.Tickets do
     %{name: "Entry", description: "Entrada nos 4 dias do evento", icon: "fa-ticket-solid", color: "#D93044", active: true, priority: 0},
     %{name: "Meals", description: "Refeições durante todo o evento", icon: "fa-utensils-solid", color: "#F18F01", active: true, priority: 1},
     %{name: "Accommodation", description: "Estadia no Pavilhão", icon: "fa-bed-solid", color: "#2E86AB", active: true, priority: 2},
-
-    %{name: "Arraial Minhoto Entry", description: "Entrada no Arraial Minhoto", icon: "fa-ticket-solid", color: "#8B4513", active: true, priority: 3},
     %{name: "Rally pela Sé Entry", description: "Participação no Rally pela Sé", icon: "fa-ticket-solid", color: "#556B2F", active: true, priority: 4}
   ]
 
   @ticket_types [
-    %{name: "Passe Geral", description: "A nice ticket", price: 15, active: true, product_key: "b757d845-bbcd-4c10-ad6f-4effe3406a3c", priority: 0, perks: ["Entry"], type: :event},
-    %{name: "Passe Geral com Refeições", description: "A much nicer ticket", price: 25, active: true, product_key: "021743b2-6ff1-4666-b70c-977c303a5da1", priority: 1, perks: ["Entry", "Meals"], type: :event},
-    %{name: "Passe Geral com Refeições e Alojamento da Universidade do Minho",
-    description: "An awesome ticket", price: 35, active: true, product_key: "0ff1e663-481a-4e42-9a52-a4ac02b72437", priority: 2, perks: ["Entry", "Meals", "Accommodation"], type: :event},
-
-    %{name: "Bilhete Arraial Minhoto", description: "Acesso exclusivo ao Arraial Minhoto", price: 5, active: true, product_key: "a1b2c3d4-e5f6-4a1b-8c9d-0e1f2a3b4c5d", priority: 3, perks: ["Arraial Minhoto Entry"], type: :activity},
-    %{name: "Bilhete Rally pela Sé", description: "Acesso exclusivo ao Rally pela Sé", price: 3, active: true, product_key: "f1e2d3c4-b5a6-4f1e-8d9c-0b1a2f3e4d5c", priority: 4, perks: ["Rally pela Sé Entry"], type: :activity}
+    %{
+      name: "Passe Geral",
+      description: "A nice ticket",
+      price: 15,
+      active: true,
+      product_key: "b757d845-bbcd-4c10-ad6f-4effe3406a3c",
+      priority: 0,
+      perks: ["Entry"],
+      type: :event
+    },
+    %{
+      name: "Passe Geral com Refeições",
+      description: "A much nicer ticket",
+      price: 25,
+      active: true,
+      product_key: "021743b2-6ff1-4666-b70c-977c303a5da1",
+      priority: 1,
+      perks: ["Entry", "Meals"],
+      type: :event
+    },
+    %{
+      name: "Passe Geral com Refeições e Alojamento da Universidade do Minho",
+      description: "An awesome ticket",
+      price: 35,
+      active: true,
+      product_key: "0ff1e663-481a-4e42-9a52-a4ac02b72437",
+      priority: 2,
+      perks: ["Entry", "Meals", "Accommodation"],
+      type: :event
+    },
+    %{
+      name: "Bilhete Rally pela Sé",
+      description: "Acesso exclusivo ao Rally pela Sé",
+      price: 3,
+      active: true,
+      product_key: "f1e2d3c4-b5a6-4f1e-8d9c-0b1a2f3e4d5c",
+      priority: 4,
+      perks: ["Rally pela Sé Entry"],
+      type: :activity,
+      activity_title: "Rally de Tascas"
+    }
   ]
 
   def run do
@@ -60,8 +92,10 @@ defmodule Pearl.Repo.Seeds.Tickets do
     case Repo.all(TicketType) do
       [] ->
         Enum.each(@ticket_types, fn attrs ->
+          {activity_title, attrs} = Map.pop(attrs, :activity_title)
+
           attrs
-          |> assign_activity_id(activities)
+          |> assign_activity_id(activities, activity_title)
           |> insert_ticket_type()
         end)
 
@@ -92,21 +126,34 @@ defmodule Pearl.Repo.Seeds.Tickets do
     end
   end
 
-  defp assign_activity_id(%{type: :activity} = attrs, activities) do
+  defp assign_activity_id(%{type: :activity} = attrs, activities, activity_title) when not is_nil(activity_title) do
     case activities do
       [] ->
         Mix.raise("Cannot create activity ticket #{attrs.name}: no activities seeded.")
 
       _ ->
-        activity =
-          Enum.find(activities, &String.contains?(&1.title, attrs.name |> String.split() |> List.first() || "")) ||
-            List.first(activities)
+        case Enum.find(activities, &(&1.title == activity_title)) do
+          nil ->
+            Mix.raise("Cannot create activity ticket #{attrs.name}: no activity found with title \"#{activity_title}\".")
 
+          activity ->
+            Map.put(attrs, :activity_id, activity.id)
+        end
+    end
+  end
+
+  defp assign_activity_id(%{type: :activity} = attrs, activities, nil) do
+    case activities do
+      [] ->
+        Mix.raise("Cannot create activity ticket #{attrs.name}: no activities seeded.")
+
+      _ ->
+        activity = Enum.random(activities)
         Map.put(attrs, :activity_id, activity.id)
     end
   end
 
-  defp assign_activity_id(attrs, _activities), do: attrs
+  defp assign_activity_id(attrs, _activities, _activity_title), do: attrs
 
   defp seed_tickets do
     case Repo.all(Ticket) do
@@ -226,11 +273,6 @@ defmodule Pearl.Repo.Seeds.Tickets do
         })
       end)
     end)
-  end
-
-    defp insert_activity_ticket(other) do
-    Mix.shell().error("[BUG] insert_activity_ticket/1 called with unexpected input: #{inspect(other)}")
-    nil
   end
 
   defp insert_activity_ticket(attrs) do

--- a/test/pearl/activities_test.exs
+++ b/test/pearl/activities_test.exs
@@ -119,12 +119,12 @@ defmodule Pearl.ActivitiesTest do
     end
 
     test "create_activity_category/1 with valid data creates a activity_category" do
-      valid_attrs = %{name: "some name"}
+      valid_attrs = %{name: "Talk"}
 
       assert {:ok, %ActivityCategory{} = activity_category} =
                Activities.create_activity_category(valid_attrs)
 
-      assert activity_category.name == "some name"
+      assert activity_category.name == "Talk"
     end
 
     test "create_activity_category/1 with invalid data returns error changeset" do
@@ -133,12 +133,12 @@ defmodule Pearl.ActivitiesTest do
 
     test "update_activity_category/2 with valid data updates the activity_category" do
       activity_category = activity_category_fixture()
-      update_attrs = %{name: "some updated name"}
+      update_attrs = %{name: "Workshop"}
 
       assert {:ok, %ActivityCategory{} = activity_category} =
                Activities.update_activity_category(activity_category, update_attrs)
 
-      assert activity_category.name == "some updated name"
+      assert activity_category.name == "Workshop"
     end
 
     test "update_activity_category/2 with invalid data returns error changeset" do

--- a/test/pearl_web/landing/components/schedule_test.exs
+++ b/test/pearl_web/landing/components/schedule_test.exs
@@ -1,0 +1,130 @@
+defmodule PearlWeb.Landing.Components.ScheduleTest do
+  use ExUnit.Case, async: true
+
+  alias PearlWeb.Landing.Components.Schedule
+
+  describe "group_activities_in_blocks/1" do
+    test "groups and orders activities by start/end and category" do
+      activities = [
+        %{id: 1, time_start: ~T[14:00:00], time_end: ~T[15:00:00], category: %{name: "Talk"}},
+        %{id: 2, time_start: ~T[15:00:00], time_end: ~T[16:00:00], category: %{name: "Workshop"}},
+        %{id: 3, time_start: ~T[14:00:00], time_end: ~T[16:00:00], category: %{name: "Gameshow"}},
+        %{id: 4, time_start: ~T[14:00:00], time_end: ~T[15:00:00], category: %{name: "Workshop"}},
+        %{id: 5, time_start: ~T[14:00:00], time_end: ~T[15:00:00], category: %{name: "Talk"}}
+      ]
+
+      grouped = Schedule.group_activities_in_blocks(activities)
+
+      assert grouped == [
+               [
+                 %{
+                   id: 1,
+                   time_start: ~T[14:00:00],
+                   time_end: ~T[15:00:00],
+                   category: %{name: "Talk"}
+                 },
+                 %{
+                   id: 5,
+                   time_start: ~T[14:00:00],
+                   time_end: ~T[15:00:00],
+                   category: %{name: "Talk"}
+                 },
+                 %{
+                   id: 4,
+                   time_start: ~T[14:00:00],
+                   time_end: ~T[15:00:00],
+                   category: %{name: "Workshop"}
+                 }
+               ],
+               [
+                 %{
+                   id: 3,
+                   time_start: ~T[14:00:00],
+                   time_end: ~T[16:00:00],
+                   category: %{name: "Gameshow"}
+                 }
+               ],
+               [
+                 %{
+                   id: 2,
+                   time_start: ~T[15:00:00],
+                   time_end: ~T[16:00:00],
+                   category: %{name: "Workshop"}
+                 }
+               ]
+             ]
+    end
+
+    test "break gets its own block and appears before other activities at the same start time" do
+      activities = [
+        %{id: 1, time_start: ~T[14:00:00], time_end: ~T[14:30:00], category: %{name: "Talk"}},
+        %{id: 2, time_start: ~T[14:00:00], time_end: ~T[14:30:00], category: %{name: "Break"}},
+        %{id: 3, time_start: ~T[14:00:00], time_end: ~T[14:30:00], category: %{name: "Workshop"}}
+      ]
+
+      grouped = Schedule.group_activities_in_blocks(activities)
+
+      assert grouped == [
+               [
+                 %{
+                   id: 2,
+                   time_start: ~T[14:00:00],
+                   time_end: ~T[14:30:00],
+                   category: %{name: "Break"}
+                 }
+               ],
+               [
+                 %{
+                   id: 1,
+                   time_start: ~T[14:00:00],
+                   time_end: ~T[14:30:00],
+                   category: %{name: "Talk"}
+                 },
+                 %{
+                   id: 3,
+                   time_start: ~T[14:00:00],
+                   time_end: ~T[14:30:00],
+                   category: %{name: "Workshop"}
+                 }
+               ]
+             ]
+    end
+
+    test "multiple breaks each get their own block in chronological order" do
+      activities = [
+        %{id: 1, time_start: ~T[13:00:00], time_end: ~T[14:00:00], category: %{name: "Break"}},
+        %{id: 2, time_start: ~T[10:30:00], time_end: ~T[11:00:00], category: %{name: "Break"}},
+        %{id: 3, time_start: ~T[10:30:00], time_end: ~T[11:00:00], category: %{name: "Talk"}}
+      ]
+
+      grouped = Schedule.group_activities_in_blocks(activities)
+
+      assert grouped == [
+               [
+                 %{
+                   id: 2,
+                   time_start: ~T[10:30:00],
+                   time_end: ~T[11:00:00],
+                   category: %{name: "Break"}
+                 }
+               ],
+               [
+                 %{
+                   id: 3,
+                   time_start: ~T[10:30:00],
+                   time_end: ~T[11:00:00],
+                   category: %{name: "Talk"}
+                 }
+               ],
+               [
+                 %{
+                   id: 1,
+                   time_start: ~T[13:00:00],
+                   time_end: ~T[14:00:00],
+                   category: %{name: "Break"}
+                 }
+               ]
+             ]
+    end
+  end
+end

--- a/test/support/fixtures/activities_fixtures.ex
+++ b/test/support/fixtures/activities_fixtures.ex
@@ -35,7 +35,7 @@ defmodule Pearl.ActivitiesFixtures do
     {:ok, activity_category} =
       attrs
       |> Enum.into(%{
-        name: "some name"
+        name: "Talk"
       })
       |> Pearl.Activities.create_activity_category()
 


### PR DESCRIPTION
Breaks ficam sempre sozinhos
Qualquer atividade com categoria "Break" é separada das restantes, e cada uma forma o seu próprio bloco individual nunca partilha bloco com outra atividade.

As restantes agrupam-se por {time_start, time_end}
As atividades que não são break são agrupadas pela combinação exata de hora de início e hora de fim. Ou seja, só ficam no mesmo bloco se tiverem exactamente o mesmo time_start e o mesmo time_end.

Ordenação final
Todos os blocos (breaks e grupos normais) são ordenados por {time_start, time_end, 0_ou_1}, onde breaks recebem 0 e os restantes 1 garantindo que um break aparece sempre antes de qualquer outro bloco que comece à mesma hora.